### PR TITLE
Add pytest and some simple tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,7 @@ var/
 
 # OS
 .DS_Store
+
+# Typical virtual environment dirs
+.venv/
+venv/

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -16,6 +16,5 @@ GitHub project.
 
 ## Submitting Patches
 
-The gridscale_api_client_python source code is managed using the git distributed source control 
+The gridscale_api_client_python source code is managed using the git distributed source control
 management tool <https://www.git-scm.org/>. Please submit patches accordingly.
-

--- a/README.md
+++ b/README.md
@@ -1,19 +1,24 @@
+# gridscale_api_client_python
+
 This the official Python wrapper for gridscale's [API](https://gridscale.io/en//api-documentation/index.html). Allowing you to manage your own infrastructure from your own applications.
 
-# Prerequisites
+## Prerequisites
 
 First, the Python programming language needs to be installed. This can be done by using the [official downloads](https://www.python.org/downloads/) page.
 
-Once done, download and install via [pypi](https://pypi.org)
+Once done, download and install via [PyPI](https://pypi.org)
 
-`pip3 install gs_api_client`
+```shell
+$ pip3 install gs_api_client
+```
 
-# Introduction
+## Introduction
+
 First, you will need your [API credentials](https://my.gridscale.io/Easy/APIs/).
 
 In the [examples.py](examples/examples.py) replace the `AUTH_TOKEN` & `USER_UUID` with your credentials.
 
-# Authentication
+## Authentication
 
 These imports and configs need to be setup before other commands can be run. If you do not need synchronous or asynchronous requests, you can leave out `SyncGridscaleApiClient` & `GridscaleApiClient` respectively.
 
@@ -22,20 +27,21 @@ from gs_api_client import Configuration
 from gs_api_client import SyncGridscaleApiClient, GridscaleApiClient
 
 # Initiate the configuration
-api_config = Configuration()
-api_config.api_key['X-Auth-Token'] = "AUTH_TOKEN"
-api_config.api_key['X-Auth-UserId'] = "USER_UUID"
+config = Configuration()
+config.api_key['X-Auth-Token'] = "AUTH_TOKEN"
+config.api_key['X-Auth-UserId'] = "USER_UUID"
 
 # Setup the client
-sync_api = SyncGridscaleApiClient(configuration=api_config)
-async_api = GridscaleApiClient(configuration=api_config)
+sync_api = SyncGridscaleApiClient(configuration=config)
+async_api = GridscaleApiClient(configuration=config)
 ```
 
-# Async vs Sync Clients
+## Async vs. sync client
 
-We provide two clients `SyncGridscaleApiClient` & `GridscaleApiClient`. gridscale's API performs long running operations asynchronously in the background while returning a 202 response code, with the request identifier in the `x-request-id` response header.
+We provide two clients `SyncGridscaleApiClient` and `GridscaleApiClient`. gridscale's API performs long running operations asynchronously in the background while returning a 202 response code, with the request identifier in the `x-request-id` response header.
 
 The main differences are:
+
 - `GridscaleApiClient` exposes bare gridscale API functionality, while `SyncGridscaleApiClient` adds a convenience layer on top.
 - `SyncGridscaleApiClient` determines whether the request is sync or async.
 - Makes asynchronous operations behave as if they were synchronous:
@@ -43,51 +49,54 @@ The main differences are:
   - Throws an `AsynchronousApiError` exception, in the case of failure.
 - With most `PATCH` and `POST` requests, the synchronous client will return the resulting object instead of an empty body or just the reference.
 
-# Debugging
+## Debugging
 
 Adding this line below, will output further information for debugging
 
-```Python
-api_config.debug = True
+```python
+config.debug = True
 ```
 
-# Access response header
+## Access response header
 
 Adding `http_info=True` when instantiating the client, return value will be a tuple of response, response code and response headers (dict).
 
-```Python
+```python
 sync_api = SyncGridscaleApiClient(http_info=True)
 async_api = GridscaleApiClient(http_info=True)
 ```
 
-# Basic request examples
-    from pprint import pprint
+## Basic request examples
 
-    # Get all Servers
-    pprint(async_api.get_servers())
+```python
+from pprint import pprint
 
-    # Create a Server
-    pprint(async_api.create_server({'name':'test', 'cores': 1, 'memory': 2}))
+# Get all servers
+pprint(async_api.get_servers())
 
-    # Update a Server
-    pprint(async_api.update_server('<UUID>', {
-        'name':'windows production Server',
-        'cores': 2,
-        'memory': 4
-        }))
+# Create a server
+pprint(async_api.create_server({'name':'test', 'cores': 1, 'memory': 2}))
 
-    # Delete a Server
-    pprint(client.delete_storage('<UUID>'))
+# Update a server
+pprint(async_api.update_server('<UUID>', {
+    'name':'windows production Server',
+    'cores': 2,
+    'memory': 4
+    }))
 
-# Exhaustive list of all functions
+# Delete a server
+pprint(client.delete_storage('<UUID>'))
+```
+
+## Exhaustive list of all functions
 
 Inside the [examples.py](examples/examples.py) file, you can see some example requests to get your started. All endpoints are fully documented in our [API](https://gridscale.io/en//api-documentation/index.html)
 
-## Requests
+### Requests
 
 - get_request
 
-## Locations
+### Locations
 
 - get_locations
 - get_location
@@ -99,7 +108,7 @@ Inside the [examples.py](examples/examples.py) file, you can see some example re
 - get_location_storages
 - get_location_templates
 
-## Servers
+### Servers
 
 - get_servers
 - get_server
@@ -113,7 +122,7 @@ Inside the [examples.py](examples/examples.py) file, you can see some example re
 - update_server_power
 - server_power_shutdown
 
-### Server Relations
+### Server relations
 
 - get_server_linked_ip
 - get_server_linked_ips
@@ -135,7 +144,7 @@ Inside the [examples.py](examples/examples.py) file, you can see some example re
 - unlink_network_from_server
 - unlink_storage_from_server
 
-## Storages
+### Storages
 
 - get_storages
 - get_storage
@@ -172,7 +181,7 @@ Inside the [examples.py](examples/examples.py) file, you can see some example re
 - get_template_events
 - get_deleted_templates
 
-### Marketplace Templates
+### Marketplace templates
 
 - get_marketplace_templates
 - get_marketplace_template
@@ -181,7 +190,7 @@ Inside the [examples.py](examples/examples.py) file, you can see some example re
 - delete_marketplace_template
 - get_marketplace_template_events
 
-## Networks
+### Networks
 
 - get_network
 - get_networks
@@ -191,7 +200,7 @@ Inside the [examples.py](examples/examples.py) file, you can see some example re
 - get_network_events
 - get_deleted_networks
 
-## IPs
+### IP addresses
 
 - get_ips
 - get_ip
@@ -201,7 +210,7 @@ Inside the [examples.py](examples/examples.py) file, you can see some example re
 - get_ip_events
 - get_deleted_ips
 
-## Load Balancers
+### Load balancers
 
 - get_loadbalancers
 - get_loadbalancer
@@ -211,7 +220,7 @@ Inside the [examples.py](examples/examples.py) file, you can see some example re
 - get_loadbalancer_events
 - get_deleted_loadbalancers
 
-## PaaS
+### PaaS
 
 - get_paas_services
 - get_paas_service
@@ -228,7 +237,7 @@ Inside the [examples.py](examples/examples.py) file, you can see some example re
 - get_paas_service_templates
 - get_deleted_paas_services
 
-## Firewalls
+### Firewalls
 
 - get_firewalls
 - get_firewall
@@ -237,7 +246,7 @@ Inside the [examples.py](examples/examples.py) file, you can see some example re
 - delete_firewall
 - get_firewall_events
 
-## Iso Images
+### ISO images
 
 - get_isoimages
 - get_isoimage
@@ -247,12 +256,12 @@ Inside the [examples.py](examples/examples.py) file, you can see some example re
 - get_isoimage_events
 - get_deleted_isoimages
 
-## Labels
+### Labels
 
 - get_labels
 - get_label
 
-## SSH Keys
+### SSH keys
 
 - get_ssh_keys
 - get_ssh_key
@@ -261,11 +270,11 @@ Inside the [examples.py](examples/examples.py) file, you can see some example re
 - delete_ssh_key
 - get_ssh_key_events
 
-## Events
+### Events
 
 - event_get_all
 
-## Object Storage
+### Object storage
 
 - get_buckets
 - get_access_keys

--- a/README.md
+++ b/README.md
@@ -281,3 +281,16 @@ Inside the [examples.py](examples/examples.py) file, you can see some example re
 - get_access_key
 - create_access_key
 - delete_access_key
+
+## Development
+
+Create a virtual environment with all necessary dependencies and run the tests as follows:
+
+```shell
+$ python -m venv .venv
+$ source .venv/bin/activate
+$ python -m pip install -r dev-requirements.txt
+$ pytest
+```
+
+Have fun!

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,0 +1,9 @@
+urllib3>=1.15
+six>=1.10
+certifi
+python-dateutil
+pylint
+rope
+black
+pytest
+pytest-mock

--- a/gs_api_client/synchronous/client.py
+++ b/gs_api_client/synchronous/client.py
@@ -8,7 +8,7 @@ class SyncGridscaleApiClient(GridscaleApiClientBase):
         request_provider = RequestProvider(
             self,
             self.http_info)
-        for name, api_class in self._api_registry:
+        for _, api_class in self._api_registry:
             api = SyncApi(
                 self.api_client,
                 api_class,

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,4 @@
+# See https://docs.pytest.org/en/latest/reference.html#configuration-options
+
+[pytest]
+testpaths = tests

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,17 @@
+from typing import Iterator
+
+import pytest
+
+from gs_api_client import SyncGridscaleApiClient, Configuration
+
+
+@pytest.fixture
+def client() -> Iterator[SyncGridscaleApiClient]:
+    """Fixture that creates and configures a synchronous API client."""
+
+    c = Configuration()
+    c.host = "https://example.com"
+    c.api_key["X-Auth-Token"] = "fake-token"
+    c.api_key["X-Auth-UserId"] = "not-a-uuid"
+
+    yield SyncGridscaleApiClient(configuration=c)

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,0 +1,11 @@
+from gs_api_client import Configuration
+
+
+def test_debug_is_disabled_by_default():
+    config = Configuration()
+    assert not config.debug
+
+
+def test_tls_certs_are_verified_by_default():
+    config = Configuration()
+    assert config.verify_ssl

--- a/tests/test_sync_request.py
+++ b/tests/test_sync_request.py
@@ -1,0 +1,26 @@
+from gs_api_client import Configuration, SyncGridscaleApiClient
+
+
+def test_get_servers(client, mocker):
+    mock_api = mocker.patch.object(client.api_client, "call_api")
+    mock_api.return_value = (mocker.ANY, 200, None)
+
+    client.get_servers()
+
+    mock_api.assert_called_once_with(
+        "/objects/servers",
+        "GET",
+        mocker.ANY,
+        mocker.ANY,
+        mocker.ANY,
+        body=mocker.ANY,
+        post_params=mocker.ANY,
+        files=mocker.ANY,
+        response_type=mocker.ANY,
+        auth_settings=mocker.ANY,
+        async_req=mocker.ANY,
+        _return_http_data_only=mocker.ANY,
+        collection_formats=mocker.ANY,
+        _preload_content=mocker.ANY,
+        _request_timeout=mocker.ANY,
+    )


### PR DESCRIPTION
This PR adds simple unit testing to this lib.
                                                                                               
It uses pytest framework to execute few simple tests that just check the most basic things.                                                                              

- tests.test_config: checks that config has sane defaults                                  
- tests.test_sync_request: check that we can render a basic GET request for /objects/servers                                                                     
- test.conftest: fixture for SyncGridscaleApiClient
- pytest.ini: ini file for pytest that just limits test discovery to tests/ directory (much faster)                                                           
- dev-requirements.txt: contains all dependencies to run the tests plus a few other Python dev tools for linting, refactoring, and formatting (notably pylint, rope, black)

You can run the tests in this PR with:                                                                
```shell                          
$ python -m venv .venv
$ source .venv/bin/activate
$ python -m pip install -r dev-requirements.txt
$ pytest
```

There are also some drive-by changes (markdown files and minor warnings in Python files). Sorry for the noise.